### PR TITLE
feat: add Task and impl Receive with timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # Changes
 
+## Unreleased
+
+* Introduce SSL module to turn sockets into SSL-backed Reader/Writer streams.
+  This includes making a `Net.Socket.stream_socket` into a client or a server
+  SSL-backed stream pair.
+
+* Introduce monotomic timers with nanosecond precision. Thansk to the `mtime`
+  library this was a breeze!
+
+* Introduce timeouts in `receive` – you can now call `receive ~after:10L ()`
+  and if there are messages fetched in 10 microseconds `receive` will raise a
+  `Receive_timeout` exception that you can match on.
+
+* Introduce `Task` to quickly spin up processes that we can await. This is the
+  closest we have to a future. A `Task` is typed, executes a single function, 
+  and MUST be awaited with `Task.await ?timeout task`.
+
+* Introduce specialized Dashmap's with the `Dashmap.Make` functor.
+
+* Improve `Timer_wheel` with support for clearing timers, and iterating timers
+  in the order in which they were created.
+
 ## 0.0.7
 
 * Introduce IO module with low-level IO operations such as performing direct

--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,7 @@
   (x509 (and :with-test (>= "0.16.5")))
   (castore (and :with-test (>= "0.0.2")))
   (mdx (and :with-test (>= "2.3.1")))
+  (mtime (>= "2.0.0"))
   (ocaml (>= "5.1"))
   (odoc (and :with-doc (>= "2.2.2")))
   (poll (>= "0.3.1"))
@@ -31,6 +32,7 @@
   (telemetry (>= "0.0.1"))
   (tls (>="0.17.3"))
   (uri (>= "4.4.0"))
+  (x509 (and :with-test (>= "0.16.5")))
   dune)
  (tags
   (multicore erlang actor "message-passing" processes)))

--- a/riot.opam
+++ b/riot.opam
@@ -14,6 +14,7 @@ depends: [
   "x509" {with-test & >= "0.16.5"}
   "castore" {with-test & >= "0.0.2"}
   "mdx" {with-test & >= "2.3.1"}
+  "mtime" {>= "2.0.0"}
   "ocaml" {>= "5.1"}
   "odoc" {with-doc & >= "2.2.2"}
   "poll" {>= "0.3.1"}
@@ -21,6 +22,7 @@ depends: [
   "telemetry" {>= "0.0.1"}
   "tls" {>= "0.17.3"}
   "uri" {>= "4.4.0"}
+  "x509" {with-test & >= "0.16.5"}
   "dune" {>= "3.11"}
 ]
 build: [

--- a/riot/lib/lib.ml
+++ b/riot/lib/lib.ml
@@ -7,4 +7,6 @@ module Net = Net
 module Queue = Runtime.Lf_queue
 module SSL = Ssl
 module Supervisor = Supervisor
+module Task = Task
 module Telemetry = Telemetry_app
+module Timeout = Timeout

--- a/riot/lib/net.ml
+++ b/riot/lib/net.ml
@@ -48,7 +48,6 @@ module Socket = struct
     addr : Addr.tcp_addr;
   }
 
-  type timeout = Infinity | Bounded of float
   type unix_error = [ `Unix_error of Unix.error ]
   type ('ok, 'err) result = ('ok, ([> unix_error ] as 'err)) Stdlib.result
 
@@ -92,7 +91,7 @@ module Socket = struct
     Logger.trace (fun f -> f "Connecting to %a via %a" Addr.pp addr pp fd);
     Ok fd
 
-  let rec accept ?(timeout = Infinity) (socket : listen_socket) =
+  let rec accept ?(timeout = `infinity) (socket : listen_socket) =
     let pool = Scheduler.Pool.get_pool () in
     Log.trace (fun f -> f "Socket is Accepting client at fd=%a" Fd.pp socket);
     match Low_level.accept pool.io_scheduler.io_tbl socket with
@@ -103,7 +102,7 @@ module Socket = struct
 
   let controlling_process _socket ~new_owner:_ = Ok ()
 
-  let rec receive ?(timeout = Infinity) ~buf socket =
+  let rec receive ?(timeout = `infinity) ~buf socket =
     match Low_level.readv socket [| Io.Buffer.as_cstruct buf |] with
     | exception Fd.(Already_closed _) -> Error `Closed
     | `Abort reason -> Error (`Unix_error reason)

--- a/riot/lib/task.ml
+++ b/riot/lib/task.ml
@@ -1,0 +1,29 @@
+open Runtime
+
+type 'a t = { pid : Pid.t; ref : 'a Ref.t; value : 'a option }
+type Message.t += Reply : 'a Ref.t * 'a -> Message.t
+
+let async fn =
+  let ref = Ref.make () in
+  let this = self () in
+  let pid =
+    spawn (fun () ->
+        Log.trace (fun f -> f "spawned task %a" Pid.pp (self ()));
+        send this (Reply (ref, fn ())))
+  in
+  monitor this pid;
+  { pid; ref; value = None }
+
+let await :
+    type res.
+    ?timeout:int64 -> res t -> (res, [> `Timeout | `Process_down ]) result =
+ fun ?timeout:after t ->
+  match receive ?after ~ref:t.ref () with
+  | exception Receive_timeout -> Error `Timeout
+  | Process.Messages.Monitor (Process_down pid) when pid = t.pid ->
+      Error `Process_down
+  | Reply (ref', res) -> (
+      match Ref.type_equal t.ref ref' with
+      | Some Type.Equal -> Ok res
+      | None -> failwith "bad message")
+  | _ -> failwith "unexpected message"

--- a/riot/lib/timeout.ml
+++ b/riot/lib/timeout.ml
@@ -1,0 +1,1 @@
+type t = [ `infinity | `after of int64 ]

--- a/riot/runtime/core/proc_effect.ml
+++ b/riot/runtime/core/proc_effect.ml
@@ -1,6 +1,11 @@
 open Util
 
-type _ Effect.t += Receive : { ref : unit Ref.t option } -> Message.t Effect.t
+type _ Effect.t +=
+  | Receive : {
+      ref : 'a Ref.t option;
+      timeout : Timeout.t;
+    }
+      -> Message.t Effect.t
   [@@unboxed]
 
 type _ Effect.t += Yield : unit Effect.t [@@unboxed]

--- a/riot/runtime/core/proc_state.mli
+++ b/riot/runtime/core/proc_state.mli
@@ -16,5 +16,6 @@ type 'a step =
 type ('a, 'b) step_callback = ('a step -> 'b t) -> 'a Effect.t -> 'b t
 type perform = { perform : 'a 'b. ('a, 'b) step_callback } [@@unboxed]
 
+val pp : Format.formatter -> 'a t -> unit
 val make : ('a -> 'b) -> 'a Effect.t -> 'b t
 val run : reductions:int -> perform:perform -> 'a t -> 'a t

--- a/riot/runtime/core/process.mli
+++ b/riot/runtime/core/process.mli
@@ -1,5 +1,9 @@
 open Util
 
+module Exn : sig
+  exception Receive_timeout
+end
+
 type exit_reason =
   | Normal
   | Exit_signal
@@ -9,7 +13,7 @@ type exit_reason =
 
 module Messages : sig
   type monitor = Process_down of Pid.t
-  type Message.t += Monitor of monitor | Exit of Pid.t * exit_reason
+  type Message.t += Monitor of monitor | Exit of Pid.t * exit_reason | Timeout
 end
 
 type state =
@@ -37,45 +41,49 @@ type t = {
   links : Pid.t list Atomic.t;
   monitors : Pid.t list Atomic.t;
   ready_fds : Fd.t list Atomic.t;
+  recv_timeout : unit Ref.t option Atomic.t;
 }
 
 exception Process_reviving_is_forbidden of t
 
-val make : Scheduler_uid.t -> (unit -> exit_reason) -> t
-val pp : Format.formatter -> t -> unit
-val pp_state : Format.formatter -> state -> unit
-val pp_reason : Format.formatter -> exit_reason -> unit
-val pp_flags : Format.formatter -> process_flags -> unit
+val add_link : t -> Pid.t -> unit
+val add_monitor : t -> Pid.t -> unit
+val add_to_save_queue : t -> Message.envelope -> unit
+val clear_receive_timeout : t -> unit
 val cont : t -> exit_reason Proc_state.t
-val pid : t -> Pid.t
-val sid : t -> Scheduler_uid.t
-val state : t -> state
-val monitors : t -> Pid.t list
-val links : t -> Pid.t list
-val is_alive : t -> bool
-val is_exited : t -> bool
-val is_waiting : t -> bool
-val is_waiting_io : t -> bool
-val is_runnable : t -> bool
-val is_running : t -> bool
-val is_finalized : t -> bool
 val has_empty_mailbox : t -> bool
 val has_messages : t -> bool
 val has_ready_fds : t -> bool
-val set_ready_fds : t -> Fd.t list -> unit
-val message_count : t -> int
-val should_awake : t -> bool
+val is_alive : t -> bool
+val is_exited : t -> bool
+val is_finalized : t -> bool
+val is_runnable : t -> bool
+val is_running : t -> bool
+val is_waiting : t -> bool
+val is_waiting_io : t -> bool
+val links : t -> Pid.t list
+val make : Scheduler_uid.t -> (unit -> exit_reason) -> t
 val mark_as_awaiting_io : t -> string -> [ `r | `rw | `w ] -> Fd.t -> unit
 val mark_as_awaiting_message : t -> unit
-val mark_as_running : t -> unit
-val mark_as_runnable : t -> unit
 val mark_as_exited : t -> exit_reason -> unit
 val mark_as_finalized : t -> unit
-val set_flag : t -> process_flag -> unit
-val set_cont : t -> exit_reason Proc_state.t -> unit
-val add_link : t -> Pid.t -> unit
-val add_monitor : t -> Pid.t -> unit
+val mark_as_runnable : t -> unit
+val mark_as_running : t -> unit
+val message_count : t -> int
+val monitors : t -> Pid.t list
 val next_message : t -> Message.envelope option
-val add_to_save_queue : t -> Message.envelope -> unit
+val pid : t -> Pid.t
+val pp : Format.formatter -> t -> unit
+val pp_flags : Format.formatter -> process_flags -> unit
+val pp_reason : Format.formatter -> exit_reason -> unit
+val pp_state : Format.formatter -> state -> unit
 val read_save_queue : t -> unit
+val receive_timeout : t -> unit Ref.t option
 val send_message : t -> Message.t -> unit
+val set_cont : t -> exit_reason Proc_state.t -> unit
+val set_flag : t -> process_flag -> unit
+val set_ready_fds : t -> Fd.t list -> unit
+val set_receive_timeout : t -> unit Ref.t -> unit
+val should_awake : t -> bool
+val sid : t -> Scheduler_uid.t
+val state : t -> state

--- a/riot/runtime/core/ref.ml
+++ b/riot/runtime/core/ref.ml
@@ -17,3 +17,4 @@ let type_equal : type a b. a t -> b t -> (a, b) Type.eq option =
   | _ -> None
 
 let is_newer (Ref a) (Ref b) = Int64.compare a b = 1
+let hash (Ref a) = Int64.hash a

--- a/riot/runtime/core/ref.mli
+++ b/riot/runtime/core/ref.mli
@@ -2,6 +2,7 @@ type 'a t
 
 val make : unit -> 'a t
 val equal : 'a t -> 'b t -> bool
+val hash : 'a t -> int
 val type_equal : 'a 'b. 'a t -> 'b t -> ('a, 'b) Type.eq option
 val pp : Format.formatter -> 'a t -> unit
 val is_newer : 'a t -> 'b t -> bool

--- a/riot/runtime/import.ml
+++ b/riot/runtime/import.ml
@@ -16,7 +16,12 @@ let syscall name mode fd cb =
   Effect.perform (Proc_effect.Syscall { name; mode; fd });
   cb fd
 
-let receive ?ref () = Effect.perform (Proc_effect.Receive { ref })
+let receive ?after ?ref () =
+  let timeout =
+    match after with None -> `infinity | Some after -> `after after
+  in
+  Effect.perform (Proc_effect.Receive { ref; timeout })
+
 let yield () = Effect.perform Proc_effect.Yield
 let random () = (_get_sch ()).rnd
 
@@ -154,6 +159,7 @@ let rec wait_pids pids =
   | pid :: tail -> wait_pids (if is_process_alive pid then pids else tail)
 
 module Timer = struct
+  type timeout = Util.Timeout.t
   type timer = unit Ref.t
 
   let _set_timer pid msg time mode =

--- a/riot/runtime/runtime.ml
+++ b/riot/runtime/runtime.ml
@@ -4,3 +4,4 @@ include Core
 include Import
 include Util
 include Core.Proc_registry.Exn
+include Core.Process.Exn

--- a/riot/runtime/scheduler/scheduler.mli
+++ b/riot/runtime/scheduler/scheduler.mli
@@ -36,7 +36,7 @@ val set_current_process_pid : Pid.t -> unit
 val get_random_scheduler : pool -> t
 
 val set_timer :
-  t -> float -> [ `interval | `one_off ] -> (unit -> unit) -> unit Ref.t
+  t -> int64 -> [ `interval | `one_off ] -> (unit -> unit) -> unit Ref.t
 
 val add_to_run_queue : t -> Process.t -> unit
 val awake_process : pool -> Process.t -> unit

--- a/riot/runtime/time/dune
+++ b/riot/runtime/time/dune
@@ -1,4 +1,4 @@
 (library
  (package riot)
  (name time)
- (libraries core ptime ptime.clock.os))
+ (libraries core mtime mtime.clock.os))

--- a/riot/runtime/time/timer_wheel.mli
+++ b/riot/runtime/time/timer_wheel.mli
@@ -4,17 +4,18 @@ module Timer : sig
   type t
 
   val pp : Format.formatter -> t -> unit
-  val make : float -> [ `interval | `one_off ] -> (unit -> unit) -> t
+  val make : int64 -> [ `interval | `one_off ] -> (unit -> unit) -> t
   val equal : t -> t -> bool
 end
 
 type t
 
 val create : unit -> t
+val is_finished : t -> unit Ref.t -> bool
 
 val make_timer :
-  t -> float -> [ `interval | `one_off ] -> (unit -> unit) -> unit Ref.t
+  t -> int64 -> [ `interval | `one_off ] -> (unit -> unit) -> unit Ref.t
 
-val ends_at : Ptime.t -> Ptime.span -> Ptime.t
+val clear_timer : t -> unit Ref.t -> unit
 val tick : t -> unit
 val can_tick : t -> bool

--- a/riot/runtime/util/dashmap.ml
+++ b/riot/runtime/util/dashmap.ml
@@ -37,3 +37,60 @@ let pp k_pp fmt t =
     ~pp_sep:(fun fmt _ -> Format.fprintf fmt ", ")
     (fun fmt (k, _) -> k_pp fmt k)
     fmt (entries t)
+
+module type Base = sig
+  type key
+
+  val hash : key -> int
+  val equal : key -> key -> bool
+end
+
+module Make (B : Base) = struct
+  module Hashtbl = Hashtbl.Make (struct
+    type t = B.key
+
+    let hash = B.hash
+    let equal = B.equal
+  end)
+
+  type key = B.key
+  type 'v t = { tbl : 'v Hashtbl.t; lock : Mutex.t }
+
+  let create size = { lock = Mutex.create (); tbl = Hashtbl.create size }
+  let get t k = Mutex.protect t.lock (fun () -> Hashtbl.find_all t.tbl k)
+  let remove t k = Mutex.protect t.lock (fun () -> Hashtbl.remove t.tbl k)
+
+  let remove_all t ks =
+    Mutex.protect t.lock (fun () -> List.iter (Hashtbl.remove t.tbl) ks)
+
+  let entries t =
+    Mutex.protect t.lock (fun () -> Hashtbl.to_seq t.tbl |> List.of_seq)
+
+  let find_by t fn =
+    Mutex.protect t.lock (fun () -> Hashtbl.to_seq t.tbl |> Seq.find fn)
+
+  let find_all_by t fn =
+    Mutex.protect t.lock (fun () ->
+        Hashtbl.to_seq t.tbl |> Seq.filter fn |> List.of_seq)
+
+  let iter t fn = Hashtbl.iter (fun k v -> fn (k, v)) t.tbl
+  let has_key t k = Mutex.protect t.lock (fun () -> Hashtbl.mem t.tbl k)
+  let is_empty t = Mutex.protect t.lock (fun () -> Hashtbl.length t.tbl = 0)
+
+  let insert t k v =
+    Mutex.protect t.lock (fun () -> Hashtbl.add t.tbl k v |> ignore)
+
+  let remove_by t fn =
+    Mutex.protect t.lock (fun () ->
+        Hashtbl.to_seq t.tbl |> Seq.filter fn
+        |> Seq.map (fun (k, _v) -> k)
+        |> Seq.iter (fun k -> Hashtbl.remove t.tbl k))
+
+  let replace t k v = Mutex.protect t.lock (fun () -> Hashtbl.replace t.tbl k v)
+
+  let pp k_pp fmt t =
+    Format.pp_print_list
+      ~pp_sep:(fun fmt _ -> Format.fprintf fmt ", ")
+      (fun fmt (k, _) -> k_pp fmt k)
+      fmt (entries t)
+end

--- a/riot/runtime/util/dashmap.mli
+++ b/riot/runtime/util/dashmap.mli
@@ -15,3 +15,29 @@ val iter : ('k, 'v) t -> ('k * 'v -> unit) -> unit
 
 val pp :
   (Format.formatter -> 'k -> unit) -> Format.formatter -> ('k, 'v) t -> unit
+
+module type Base = sig
+  type key
+
+  val hash : key -> int
+  val equal : key -> key -> bool
+end
+
+module Make (B : Base) : sig
+  type key = B.key
+  type 'v t
+
+  val create : int -> 'v t
+  val get : 'v t -> key -> 'v list
+  val is_empty : 'v t -> bool
+  val find_by : 'v t -> (key * 'v -> bool) -> (key * 'v) option
+  val remove : 'v t -> key -> unit
+  val remove_all : 'v t -> key list -> unit
+  val find_all_by : 'v t -> (key * 'v -> bool) -> (key * 'v) list
+  val has_key : 'v t -> key -> bool
+  val insert : 'v t -> key -> 'v -> unit
+  val remove_by : 'v t -> (key * 'v -> bool) -> unit
+  val replace : 'v t -> key -> 'v -> unit
+  val iter : 'v t -> (key * 'v -> unit) -> unit
+  val pp : (Format.formatter -> key -> unit) -> Format.formatter -> 'v t -> unit
+end

--- a/riot/runtime/util/timeout.ml
+++ b/riot/runtime/util/timeout.ml
@@ -1,0 +1,1 @@
+type t = [ `infinity | `after of int64 ]

--- a/test/add_monitor_test.ml
+++ b/test/add_monitor_test.ml
@@ -9,7 +9,7 @@ let main () =
   let pid = spawn (fun () -> ()) in
   monitor this pid;
 
-  match receive () with
+  match receive ~after:500_000L () with
   | Process.Messages.Monitor (Process_down pid2) when Pid.equal pid pid2 ->
       Logger.debug (fun f -> f "add_monitor: was notified of process death");
       Logger.info (fun f -> f "add_monitor: OK");

--- a/test/dune
+++ b/test/dune
@@ -137,3 +137,13 @@
  (name telemetry_test)
  (modules telemetry_test)
  (libraries riot))
+
+(test
+ (name receive_timeout_test)
+ (modules receive_timeout_test)
+ (libraries riot))
+
+(test
+ (name task_test)
+ (modules task_test)
+ (libraries riot))

--- a/test/net_reader_writer_test.ml
+++ b/test/net_reader_writer_test.ml
@@ -98,7 +98,7 @@ let () =
   let client = spawn (fun () -> client port main) in
   monitor main server;
   monitor main client;
-  match receive () with
+  match receive ~after:500_000L () with
   | Received "hello world" ->
       Logger.info (fun f -> f "net_reader_writer_test: OK");
       sleep 0.001;

--- a/test/net_test.ml
+++ b/test/net_test.ml
@@ -91,7 +91,11 @@ let () =
   let client = spawn (fun () -> client port main) in
   monitor main server;
   monitor main client;
-  match receive () with
+  match receive ~after:100_000L () with
+  | exception Receive_timeout ->
+      Logger.error (fun f -> f "net_test: test timed out");
+      sleep 0.001;
+      Stdlib.exit 1
   | Received "hello world" ->
       Logger.info (fun f -> f "net_test: OK");
       sleep 0.001;

--- a/test/process_registration_test.ml
+++ b/test/process_registration_test.ml
@@ -25,7 +25,7 @@ module Registry_test = struct
 
     send_by_name ~name:pid_name Hello;
 
-    (match[@warning "-8"] receive () with
+    (match[@warning "-8"] receive ~after:500_000L () with
     | Hello ->
         Logger.debug (fun f ->
             f "process_registration_test: send_by_name works"));

--- a/test/receive_timeout_test.ml
+++ b/test/receive_timeout_test.ml
@@ -1,0 +1,19 @@
+open Riot
+
+type Message.t += Unexpected
+
+let () =
+  Riot.run @@ fun () ->
+  let _ = Logger.start () |> Result.get_ok in
+  Logger.set_log_level (Some Info);
+  let _ = Timer.send_after (self ()) Unexpected ~after:100L |> Result.get_ok in
+
+  match receive ~after:1L () with
+  | exception Receive_timeout ->
+      Logger.info (fun f -> f "receive_timeout_test: OK");
+      sleep 0.001;
+      shutdown ()
+  | _ ->
+      Logger.error (fun f -> f "receive_timeout_test: unexpected message");
+      sleep 0.001;
+      Stdlib.exit 1

--- a/test/selective_receive_test.ml
+++ b/test/selective_receive_test.ml
@@ -6,14 +6,17 @@ type Message.t += A | B | C | Continue
 
 let loop pid =
   send pid A;
-  receive () |> ignore;
+  receive ~after:500_000L () |> ignore;
   send pid B;
   send pid C
 
 let rec collect_messages ref count =
   if count = 0 then []
   else
-    let msg = if count = 1 then receive () else receive ~ref () in
+    let msg =
+      if count = 1 then receive ~after:500_000L ()
+      else receive ~after:500_000L ~ref ()
+    in
     Logger.debug (fun f -> f "received messgge: %s" (Marshal.to_string msg []));
     msg :: collect_messages ref (count - 1)
 

--- a/test/send_after_test.ml
+++ b/test/send_after_test.ml
@@ -16,10 +16,10 @@ let main () =
   let (Ok _) = Logger.start () in
   let this = self () in
 
-  let (Ok _timer) = Timer.send_after this A ~after:1.0 in
-  let (Ok _timer) = Timer.send_after this C ~after:2.0 in
-  let (Ok _timer) = Timer.send_after this D ~after:3.0 in
-  let (Ok _timer) = Timer.send_after this E ~after:4.0 in
+  let (Ok _timer) = Timer.send_after this A ~after:10L in
+  let (Ok _timer) = Timer.send_after this C ~after:20L in
+  let (Ok _timer) = Timer.send_after this D ~after:30L in
+  let (Ok _timer) = Timer.send_after this E ~after:40L in
   send this B;
 
   let messages =

--- a/test/send_after_test.ml
+++ b/test/send_after_test.ml
@@ -22,8 +22,16 @@ let main () =
   let (Ok _timer) = Timer.send_after this E ~after:40L in
   send this B;
 
+  let after = 10_000L in
   let messages =
-    [ receive (); receive (); receive (); receive (); receive () ] |> List.rev
+    [
+      receive ~after ();
+      receive ~after ();
+      receive ~after ();
+      receive ~after ();
+      receive ~after ();
+    ]
+    |> List.rev
   in
 
   let _ =

--- a/test/send_interval_test.ml
+++ b/test/send_interval_test.ml
@@ -8,7 +8,7 @@ let main () =
   let (Ok _) = Logger.start () in
   let this = self () in
 
-  let (Ok _timer) = Timer.send_interval this A ~every:0.5 in
+  let (Ok _timer) = Timer.send_interval this A ~every:50L in
 
   let A = receive () in
   let A = receive () in

--- a/test/send_interval_test.ml
+++ b/test/send_interval_test.ml
@@ -10,8 +10,8 @@ let main () =
 
   let (Ok _timer) = Timer.send_interval this A ~every:50L in
 
-  let A = receive () in
-  let A = receive () in
+  let A = receive ~after:1000L () in
+  let A = receive ~after:1000L () in
 
   Logger.debug (fun f -> f "send_interval_test: messages sent with interval");
   Logger.info (fun f -> f "send_interval_test: OK");

--- a/test/send_order_test.ml
+++ b/test/send_order_test.ml
@@ -10,7 +10,7 @@ type Riot.Message.t +=
 type state = { messages : Riot.Message.t list; main : Pid.t }
 
 let rec loop state =
-  match receive () with
+  match receive ~after:500_000L () with
   | End -> send state.main (Collected_messages (List.rev state.messages))
   | A _ as msg -> loop { state with messages = msg :: state.messages }
   | _ -> loop state
@@ -25,7 +25,7 @@ let main () =
   send pid (A 3);
   send pid End;
 
-  match receive () with
+  match receive ~after:500_000L () with
   | Collected_messages [ A 1; A 2; A 3 ] ->
       Logger.debug (fun f -> f "send_order_test: received messages in order");
       Logger.info (fun f -> f "send_order_test: OK");

--- a/test/ssl_test.ml
+++ b/test/ssl_test.ml
@@ -139,7 +139,7 @@ let () =
   in
   monitor main server;
   monitor main client;
-  match receive () with
+  match receive ~after:500_000L () with
   | Received "hello world" ->
       Logger.info (fun f -> f "ssl_test: OK");
       sleep 0.001;

--- a/test/supervisor_shutdown_test.ml
+++ b/test/supervisor_shutdown_test.ml
@@ -28,22 +28,22 @@ let main () =
     |> Result.get_ok
   in
 
-  let (Ping_me child_pid) = receive () in
+  let (Ping_me child_pid) = receive ~after:500_000L () in
   Logger.debug (fun f -> f "received pid %a" Pid.pp child_pid);
 
   exit child_pid Process.Exit_signal;
 
-  let (Ping_me child_pid) = receive () in
+  let (Ping_me child_pid) = receive ~after:500_000L () in
   Logger.debug (fun f -> f "received pid %a" Pid.pp child_pid);
 
   exit child_pid Process.Exit_signal;
 
-  let (Ping_me child_pid) = receive () in
+  let (Ping_me child_pid) = receive ~after:500_000L () in
   Logger.debug (fun f -> f "received pid %a" Pid.pp child_pid);
 
   exit child_pid Process.Exit_signal;
 
-  match receive () with
+  match receive ~after:500_000L () with
   | Process.Messages.Exit (pid, _reason) when Pid.equal pid sup ->
       Logger.info (fun f ->
           f "supervisor_shutdown_test: supervisor finished as expected");

--- a/test/task_test.ml
+++ b/test/task_test.ml
@@ -1,0 +1,29 @@
+open Riot
+
+let rec count_to x n =
+  if x = n then n
+  else (
+    yield ();
+    count_to (x + 1) n)
+
+let () =
+  Riot.run @@ fun () ->
+  let _ = Logger.start () |> Result.get_ok in
+  Logger.set_log_level (Some Info);
+
+  let task = Task.async (fun () -> count_to 0 10_000) in
+
+  match Task.await ~timeout:100_000L task with
+  | Ok n ->
+      Logger.debug (fun f -> f "task_test: finished with %d" n);
+      Logger.info (fun f -> f "task_test: OK");
+      sleep 0.001;
+      shutdown ()
+  | Error `Timeout ->
+      Logger.error (fun f -> f "task_test: timeout");
+      sleep 0.001;
+      Stdlib.exit 1
+  | _ ->
+      Logger.error (fun f -> f "net_test: unexpected message");
+      sleep 0.001;
+      Stdlib.exit 1


### PR DESCRIPTION
Before this change, when you did a call to `receive ()` you were potentially stuck. Receive would not return a message until one exists, so if you didn't set up a timer like `Timer.send_after (self ()) Wake_up` then you'd get stuck.

This PR implements `receive ~after:1000L ()` that will _either_ return a message, or, if `1000L` microseconds have passed, raise a `Received_timeout` exception.

This means you can now match on your receive calls like this:

```ocaml
match receive ~after:1000L () with
| exception Receive_timeout ->
   (* recover! *)
| msg -> 
   (* handle message *)
```

Receive timeouts allow us to implement patterns where a single process is coordinating work but needs to also do some bookkeeping, without needing to set up timers.

Once we had this, it was low-hanging fruit to introduce a `Task` abstraction for creating one-off processes that run a function, and return the value. This lets us do fork-joins rather easily:

```ocaml
let funs = [ run_x; run_y; run_z; ... ]
let work = List.map Task.async funs in
let results = List.map Task.await work in
(* ... *)
```

To implement both of these, we moved to `mtime` to use as an internal monotonic timer, which also gives us microsecond precision on timers. In practice timers may be off by more than a single microsecond, potentially even milliseconds, but they would never be earlier than the microsecond offset specified.

I also added timeouts to all the receives in the tests.