### PR TITLE
 Make timers cancellable #10

### DIFF
--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -642,6 +642,8 @@ module Timer : sig
 
   val send_interval :
     Pid.t -> Message.t -> every:int64 -> (timer, [> `Timer_error ]) result
+
+  val cancel : timer -> unit
 end
 
 module Queue : sig

--- a/riot/runtime/import.ml
+++ b/riot/runtime/import.ml
@@ -171,4 +171,8 @@ module Timer = struct
 
   let send_after pid msg ~after:time = _set_timer pid msg time `one_off
   let send_interval pid msg ~every:time = _set_timer pid msg time `interval
+
+  let cancel timer =
+    let sch = _get_sch () in
+    Scheduler.remove_timer sch timer
 end

--- a/riot/runtime/scheduler/scheduler.ml
+++ b/riot/runtime/scheduler/scheduler.ml
@@ -60,6 +60,8 @@ module Scheduler = struct
   let set_timer sch time mode fn =
     Timer_wheel.make_timer sch.timers time mode fn
 
+  let remove_timer sch timer = Timer_wheel.remove_timer sch.timers timer
+
   let add_to_run_queue (sch : t) (proc : Process.t) =
     Mutex.protect sch.idle_mutex @@ fun () ->
     Proc_set.remove sch.sleep_set proc;

--- a/riot/runtime/scheduler/scheduler.mli
+++ b/riot/runtime/scheduler/scheduler.mli
@@ -38,6 +38,7 @@ val get_random_scheduler : pool -> t
 val set_timer :
   t -> int64 -> [ `interval | `one_off ] -> (unit -> unit) -> unit Ref.t
 
+val remove_timer : t -> unit Ref.t -> unit
 val add_to_run_queue : t -> Process.t -> unit
 val awake_process : pool -> Process.t -> unit
 val run : pool -> t -> unit -> unit

--- a/riot/runtime/time/timer_wheel.ml
+++ b/riot/runtime/time/timer_wheel.ml
@@ -47,6 +47,12 @@ let is_finished t timer =
   let timer_is_finished = List.exists Timer.is_finished timers in
   timer_exists && timer_is_finished
 
+let remove_timer t timer =
+  let timers = Dashmap.get t.ids timer in
+  let times = List.map (fun (timer : Timer.t) -> timer.started_at) timers in
+  Dashmap.remove_by t.ids (fun (k, _) -> Ref.equal k timer);
+  Dashmap.remove_all t.timers times
+
 let clear_timer t tid =
   Dashmap.get t.ids tid
   |> List.iter (fun timer ->

--- a/riot/runtime/time/timer_wheel.mli
+++ b/riot/runtime/time/timer_wheel.mli
@@ -12,6 +12,7 @@ type t
 
 val create : unit -> t
 val is_finished : t -> unit Ref.t -> bool
+val remove_timer : t -> unit Ref.t -> unit
 
 val make_timer :
   t -> int64 -> [ `interval | `one_off ] -> (unit -> unit) -> unit Ref.t

--- a/test/cancel_timer_test.ml
+++ b/test/cancel_timer_test.ml
@@ -1,0 +1,34 @@
+[@@@warning "-8"]
+
+open Riot
+
+type Message.t += A | B
+
+let main () =
+  let (Ok _) = Logger.start () in
+  let this = self () in
+
+  (* We cancel the second timer before it sends any messages, so the only
+     message in the inbox should be A (sent from the first timer) *)
+  let (Ok _timer) = Timer.send_after this A ~after:20L in
+  let (Ok timer) = Timer.send_interval this B ~every:50L in
+  Timer.cancel timer;
+  let message = receive ~after:10_000L () in
+  let _ =
+    match message with
+    | A ->
+        Logger.debug (fun f ->
+            f "cancel_timer_test: timer successfully cancelled")
+    | B ->
+        Runtime.Log.error (fun f -> f "timer not cancelled");
+        assert false
+    | _ ->
+        Runtime.Log.error (fun f -> f "no message sent");
+        assert false
+  in
+
+  Logger.info (fun f -> f "cancel_timer_test: OK");
+  sleep 0.01;
+  shutdown ()
+
+let () = Riot.run @@ main

--- a/test/cancel_timer_test.ml
+++ b/test/cancel_timer_test.ml
@@ -8,14 +8,11 @@ let main () =
   let (Ok _) = Logger.start () in
   let this = self () in
 
-  (* We cancel the second timer before it sends any messages, so the only
-     message in the inbox should be A (sent from the first timer) *)
-  let (Ok _timer) = Timer.send_after this A ~after:20L in
-  let (Ok timer) = Timer.send_interval this B ~every:50L in
-  Timer.cancel timer;
-  let message = receive ~after:10_000L () in
+  let (Ok _) = Timer.send_after this A ~after:100L in
+  let (Ok t) = Timer.send_after this B ~after:10L in
+  Timer.cancel t;
   let _ =
-    match message with
+    match receive ~after:10_000L () with
     | A ->
         Logger.debug (fun f ->
             f "cancel_timer_test: timer successfully cancelled")

--- a/test/dune
+++ b/test/dune
@@ -114,6 +114,11 @@
  (libraries riot))
 
 (test
+ (name cancel_timer_test)
+ (modules cancel_timer_test)
+ (libraries riot))
+
+(test
  (name send_interval_test)
  (modules send_interval_test)
  (libraries riot))


### PR DESCRIPTION
I implemented a feature to make timers cancellable.

I added a function to remove a `Timer.t` from a `Timer_wheel.t` which removes the `timer` from the `ids` and `timers` dashmaps.  After this, I added `Timer.cancel` to `riot.ml(i)`.

I wrote a test that has one timer send messages rapidly and another timer send one message.  I immediately cancel the "send_interval" timer and assert that the last received message was the one sent from the second timer.

Let me know if there's any changes you would like for me to make - thanks!