### PR TITLE
Quick fix for links-and-monitors example

### DIFF
--- a/examples/5-links-and-monitors/main.ml
+++ b/examples/5-links-and-monitors/main.ml
@@ -16,7 +16,7 @@ let () =
   let pid1 = spawn loop in
   let pid2 =
     spawn (fun () ->
-        monitor pid1;
+        monitor (self ()) pid1;
         await_monitor_message ())
   in
   sleep 0.1;


### PR DESCRIPTION
The `main.ml` file only had a single input for the `monitor` function. The `README.md` had the correct version, so I have just updated that accordingly.

Resolves: #53 