### PR TITLE
monitor does not expect `self ()` argument

### DIFF
--- a/examples/5-links-and-monitors/main.ml
+++ b/examples/5-links-and-monitors/main.ml
@@ -16,7 +16,7 @@ let () =
   let pid1 = spawn loop in
   let pid2 =
     spawn (fun () ->
-        monitor (self ()) pid1;
+        monitor pid1;
         await_monitor_message ())
   in
   sleep 0.1;


### PR DESCRIPTION
Spotted a little problem in the monitor example as it was not compiling. 
I changed it to what made the most sense to me